### PR TITLE
fix: (react-native, android) indicator is on top of items, preventing dragging selected item

### DIFF
--- a/src/NativePicker.android.tsx
+++ b/src/NativePicker.android.tsx
@@ -136,6 +136,7 @@ class Picker extends React.Component<IPickerProp & IPickerProps, any> {
     });
     return (
       <View style={style}>
+        <View ref={el => this.indicatorRef = el} style={styles.indicator}/>
         <ScrollView
           style={styles.scrollView}
           ref={el => this.scrollerRef = el}
@@ -148,7 +149,6 @@ class Picker extends React.Component<IPickerProp & IPickerProps, any> {
             {items}
           </View>
         </ScrollView>
-        <View ref={el => this.indicatorRef = el} style={styles.indicator}/>
       </View>
     );
   }


### PR DESCRIPTION
fix #48 