### PR TITLE
remove needless prop && fix the misspelling of componentWillUnmount

### DIFF
--- a/src/NativePicker.android.tsx
+++ b/src/NativePicker.android.tsx
@@ -140,7 +140,6 @@ class Picker extends React.Component<IPickerProp & IPickerProps, any> {
           style={styles.scrollView}
           ref={el => this.scrollerRef = el}
           onScroll={this.onScroll}
-          scrollEventThrottle={16}
           showsVerticalScrollIndicator={false}
           overScrollMode="never"
         >

--- a/src/NativePicker.android.tsx
+++ b/src/NativePicker.android.tsx
@@ -84,7 +84,7 @@ class Picker extends React.Component<IPickerProp & IPickerProps, any> {
     this.props.select(this.props.selectedValue, this.itemHeight, this.scrollTo);
   }
 
-  componentWillUnMount() {
+  componentWillUnmount() {
     this.clearScrollBuffer();
   }
 


### PR DESCRIPTION
1. android doesn't support scrollEventThrottle prop, so remove it.
2. fix the misspelling of componentWillUnmount