### PR TITLE
fix: android screenY initial-scale error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ xcuserdata
 yarn.lock
 package-lock.json
 _ts2js
+.history

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rmc-picker",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "React Mobile Picker Component(web and react-native)",
   "keywords": [
     "react",

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -129,15 +129,15 @@ class Picker extends React.Component<IPickerProp & IPickerProps, any> {
     };
 
     return {
-      touchstart: (evt: React.TouchEvent<HTMLDivElement>) => onStart(evt.touches[0].screenY),
-      mousedown: (evt: React.MouseEvent<HTMLDivElement>) => onStart(evt.screenY),
+      touchstart: (evt: React.TouchEvent<HTMLDivElement>) => onStart(evt.touches[0].pageY),
+      mousedown: (evt: React.MouseEvent<HTMLDivElement>) => onStart(evt.pageY),
       touchmove: (evt: React.TouchEvent<HTMLDivElement>) => {
         evt.preventDefault();
-        onMove(evt.touches[0].screenY);
+        onMove(evt.touches[0].pageY);
       },
       mousemove: (evt: React.MouseEvent<HTMLDivElement>) => {
         evt.preventDefault();
-        onMove(evt.screenY);
+        onMove(evt.pageY);
       },
       touchend: () => onFinish(),
       touchcancel: () => onFinish(),


### PR DESCRIPTION
安卓下面，如果加了高清方案，会出现 screenY 计算不准确的问题，换成 pageY

pageY 是基于 viewport 的，而 screenY 不是

https://w3c.github.io/touch-events/#touch-interface