### PR TITLE
fix: scrollTo Func cant fire callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rmc-picker",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "React Mobile Picker Component(web and react-native)",
   "keywords": [
     "react",

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -51,6 +51,8 @@ class Picker extends React.Component<IPickerProp & IPickerProps, any> {
             setTransition(this.contentRef.style, '');
           }
         }, +time * 1000);
+      } else {
+        this.scrollingComplete();
       }
     };
 


### PR DESCRIPTION
用户有可能刚好拖动一个位置，使得

> scrollY === targetY

此时虽然不用滚动动画，但还是需要触发change事件